### PR TITLE
Fix post dot get published

### DIFF
--- a/markata.toml.jinja
+++ b/markata.toml.jinja
@@ -106,7 +106,7 @@ len=250
 len=500
 
 [markata.auto_publish.filters]
-til="templateKey=='til' and date<=today and status != 'draft'"
+til="templateKey=='til' and date<=today and published == 'True'"
 
 ## SEO | <head>
 [[markata.head.text]]

--- a/markata.toml.jinja
+++ b/markata.toml.jinja
@@ -106,7 +106,7 @@ len=250
 len=500
 
 [markata.auto_publish.filters]
-til="templateKey=='til' and date<=today and published == 'True'"
+til="templateKey=='til' and date<=today and post.get('published', False)== 'True'"
 
 ## SEO | <head>
 [[markata.head.text]]

--- a/pages/index.md
+++ b/pages/index.md
@@ -16,7 +16,7 @@ your own.  Edit this page in `pages/index.md`.
 Here are some pages to help get you started. Feel free to delete them and and
 make this site your own.
 
-{% for post in markata.map('post', sort='date', filter='published==True and date<=today and "meta" in post.get("tags", [])', reverse=False) %}
+{% for post in markata.map('post', sort='date', filter='post.get("published", False)==True and date<=today and "meta" in post.get("tags", [])', reverse=False) %}
 !!! note "[{{ post['title'] }}]({{ post['slug'] }})"
     {{post['description']}}...
 {% endfor %}

--- a/pages/jinja.md
+++ b/pages/jinja.md
@@ -63,10 +63,10 @@ You can also map over posts to get more.
 
 ## Last Three Posts
 
-{% for post in markata.map('post', sort='date', filter='published==True and date<=today')[:3] %}
+{% for post in markata.map('post', sort='date', filter='post.get("published", False)==True and date<=today')[:3] %}
 *  [{{ post['title'] }}]({{ post['slug'] }}){% endfor %}
 
 ## Last Three Python posts
 
-{% for post in markata.map('post', sort='date', filter='published==True and date<=today and "meta" in post.get("tags", [])')[:3] %}
+{% for post in markata.map('post', sort='date', filter='post.get("published", False)==True and date<=today and "meta" in post.get("tags", [])')[:3] %}
 *  [{{ post['title'] }}]({{ post['slug'] }}){% endfor %}


### PR DESCRIPTION
Several filters had things like `post.get("published", False)` but some did not. I think it''s best to do the `.get` since it would allow people down the line to have an example of how to not have certain keys in the frontmatter...

That being said, maybe `published` should just be one of the required keys?

Either way a follow-up to this would be to get a better error message when the key is missing. ie. If a post doesn't have `published` as a key in the frontmatter then when markata builds you'll get a `NameError`. I found offending posts with `grep -irL published ./pages/**/*.md`. You mentioned that a markata.map would also work... So this should just be addressed in some way